### PR TITLE
Minor update and improvements in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ General options for `fritz-tls` are:
 * `--insecure` (optional) to skip TLS verification when talking to `--host` in case it's HTTPS and you currently have a broken or expired TLS certificate, or if your FRITZ!Box has its own self-signed certificate.
 * `--verification-url` (optional) to specify what URL to use to check certificate installation. Defaults to `--host`.
 * `--authcheck` (optional) to only check if the provided credentials are valid.
+* `--version` Print `fritz-tls` version and exit. All other options are ignored.
 
 `fritz-tls` can install any TLS certificate or acquire one using [Let's Encrypt](https://letsencrypt.org).
 
@@ -61,6 +62,7 @@ By default, Let's Encrypt is used to acquire a certificate, options are:
 * `--dns-provider` (default `manual`) to specify one of [lego's](https://github.com/xenolf/lego/tree/master/providers/dns) supported DNS providers. Note that you might have to set environment variables to configure your provider, e.g. `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION` and `AWS_HOSTED_ZONE_ID`. I use name servers by AWS/Route53 and [inwx](https://github.com/xenolf/lego/blob/master/providers/dns/inwx/inwx.go), so I have to provide `INWX_USERNAME`, `INWX_PASSWORD`. I'm not sure if there is a overview, so for now you have to consult the [source](https://github.com/xenolf/lego/tree/master/providers/dns).
 * `--dns-resolver` (optional) to specify the resolver to be used for recursive DNS queries. If not provided, the system default will be used. Supported format is `host:port`.
 * `--force-renew` to force a renewal, even if the current certificate is valid for the requested domain and still valid for at least the next 30 days.
+* `--acme-server` (Optional, default `https://acme-v02.api.letsencrypt.org/directory`) The server URL of the ACME server. Use `https://acme-staging-v02.api.letsencrypt.org/directory` for Let's Encrypt staging environment.
 
 ### Manual Certificate Installation
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ brew install tisba/taps/fritz-tls
 Go
 
 ```console
-go get -u github.com/tisba/fritz-tls
+go install -ldflags="-s -w" github.com/tisba/fritz-tls@latest
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ General options for `fritz-tls` are:
 * `--help` to get usage information
 * `--host` (default: `http://fritz.box`) to specify how to talk to your FRITZ!Box. If you want to login with username and password, specify the user in the URL: `--host http://tisba@fritz.box:8080`. The default username (which is sometimes randomly generated) can be found under `System` > `FRITZ!Box Users`.
 * `--password` (optional, default: '') to specify the user's password. If unspecified, `fritz-tls` will prompt the user instead.
-* `--insecure` (optional) to skip TLS verification when talking to `--host` in case it's HTTPS and you currently have a broken or expired TLS certificate.
+* `--insecure` (optional) to skip TLS verification when talking to `--host` in case it's HTTPS and you currently have a broken or expired TLS certificate, or if your FRITZ!Box has its own self-signed certificate.
 * `--verification-url` (optional) to specify what URL to use to check certificate installation. Defaults to `--host`.
 * `--authcheck` (optional) to only check if the provided credentials are valid.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ General options for `fritz-tls` are:
 
 * `--help` to get usage information
 * `--host` (default: `http://fritz.box`) to specify how to talk to your FRITZ!Box. If you want to login with username and password, specify the user in the URL: `--host http://tisba@fritz.box:8080`. The default username (which is sometimes randomly generated) can be found under `System` > `FRITZ!Box Users`.
-* `--password` (optional, default: '') to specify the user's password. If unspecified, `fritz-tls` will prompt the user instead.
+* `--password` (optional, default: '') to specify the user's password. If unspecified, `fritz-tls` will prompt the user instead. Alternatively, you may set the environment variable `FRITZTLS_ADMIN_PASS`.
 * `--insecure` (optional) to skip TLS verification when talking to `--host` in case it's HTTPS and you currently have a broken or expired TLS certificate, or if your FRITZ!Box has its own self-signed certificate.
 * `--verification-url` (optional) to specify what URL to use to check certificate installation. Defaults to `--host`.
 * `--authcheck` (optional) to only check if the provided credentials are valid.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ Although it should work with other versions as well, it is only tested with:
 * FRITZ!Box Fon WLAN 7530 (FRITZ!OS: 07.59)
 * FRITZ!Box 7490 (FRITZ!OS: 07.57)
 
-In case you want to know how to do that manually, take a look at AVM's [knowledge base article](https://en.avm.de/service/fritzbox/fritzbox-7390/knowledge-base/publication/show/1525_Importing-your-own-certificate-to-the-FRITZ-Box/).
+In case you want to know how to do that manually, take a look at AVM's knowledge base articles:
+
+* [FRITZ!Box Fon WLAN 7530](https://en.avm.de/service/knowledge-base/dok/FRITZ-Box-7530/1525_Importing-your-own-certificate-to-the-FRITZ-Box/)
+* [FRITZ!Box 7490](https://en.avm.de/service/knowledge-base/dok/FRITZ-Box-7490/1525_Importing-your-own-certificate-to-the-FRITZ-Box/)
+* [FRITZ!Box 7390](https://en.avm.de/service/knowledge-base/dok/FRITZ-Box-7390-int/1525_Importing-your-own-certificate-to-the-FRITZ-Box/)
 
 ## Installation
 
@@ -39,7 +43,7 @@ Done :)
 General options for `fritz-tls` are:
 
 * `--help` to get usage information
-* `--host` (default: `http://fritz.box`) to specify how to talk to your FRITZ!Box. If you want to login with username and password, specify the user in the URL: `--host http://tisba@fritz.box:8080`.
+* `--host` (default: `http://fritz.box`) to specify how to talk to your FRITZ!Box. If you want to login with username and password, specify the user in the URL: `--host http://tisba@fritz.box:8080`. The default username (which is sometimes randomly generated) can be found under `System` > `FRITZ!Box Users`.
 * `--insecure` (optional) to skip TLS verification when talking to `--host` in case it's HTTPS and you currently have a broken or expired TLS certificate.
 * `--verification-url` (optional) to specify what URL to use to check certificate installation. Defaults to `--host`.
 * `--authcheck` (optional) to only check if the provided credentials are valid.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ You can also provide a certificate bundle (cert + private key) directly to `frit
 fritz-tls --key=./certbot/live/demo.example.com/privkey.pem --fullchain=./certbot/live/demo.example.com/fullchain.pem
 ```
 
-* `--manual` to use a local
+* `--manual` to use a locally stored TLS material. This option is required when using either `--key` and `--fullchain` or `--bundle`.
 * `--key` and `--fullchain` to provide the private key and the certificate chain.
 * `--bundle` as an alternative for `--key` and `--fullchain`. The bundle where the password-less private key and certificate are both present.
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ General options for `fritz-tls` are:
 
 * `--help` to get usage information
 * `--host` (default: `http://fritz.box`) to specify how to talk to your FRITZ!Box. If you want to login with username and password, specify the user in the URL: `--host http://tisba@fritz.box:8080`. The default username (which is sometimes randomly generated) can be found under `System` > `FRITZ!Box Users`.
+* `--password` (optional, default: '') to specify the user's password. If unspecified, `fritz-tls` will prompt the user instead.
 * `--insecure` (optional) to skip TLS verification when talking to `--host` in case it's HTTPS and you currently have a broken or expired TLS certificate.
 * `--verification-url` (optional) to specify what URL to use to check certificate installation. Defaults to `--host`.
 * `--authcheck` (optional) to only check if the provided credentials are valid.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ You can also provide a certificate bundle (cert + private key) directly to `frit
 fritz-tls --key=./certbot/live/demo.example.com/privkey.pem --fullchain=./certbot/live/demo.example.com/fullchain.pem
 ```
 
+* `--manual` to use a local
 * `--key` and `--fullchain` to provide the private key and the certificate chain.
 * `--bundle` as an alternative for `--key` and `--fullchain`. The bundle where the password-less private key and certificate are both present.
 

--- a/main.go
+++ b/main.go
@@ -231,14 +231,14 @@ func setupConfiguration() (config configOptions) {
 		}
 
 		if config.bundle != "" {
-			log.Fatal("--bundle, --fullchain and --privatekey only work with --manual!")
+			log.Fatal("--bundle, --fullchain and --key only work with --manual!")
 		}
 	} else {
 		if config.bundle != "" {
 			config.certificateBundle = fritzutils.ReaderFromFile(config.bundle)
 		} else {
 			if config.fullchain == "" || config.privatekey == "" {
-				log.Fatal("--fullchain and --privatekey are both required, unless --bundle is used!")
+				log.Fatal("--fullchain and --key are both required, unless --bundle is used!")
 			}
 
 			config.certificateBundle = io.MultiReader(fritzutils.ReaderFromFile(config.fullchain), fritzutils.ReaderFromFile(config.privatekey))


### PR DESCRIPTION
🔗 update documentation links as the old one was returning 404 🔗 add links for more devices
📄 clarify where to get the default FRITZ!Box user
🌿 add missing `--password` general option and `FRITZTLS_ADMIN_PASS` environment variable
🌿 add missing `--manual` that's required when specifying locally stored TLS material
📄 small clarification about --insecure in the context of a default self-signed TLS certificate (which is typical when the user has never uploaded a certificate before)
🌿 document `--acme-server` and `--version`
🐛 fix error messages (x2) referencing `--privatekey` instead of `--key`
📄 update how to install `fritz-tls`
