### PR TITLE
🌿 improved file handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ BINARY=fritz-tls
 all: build
 
 build:
-	go build -o ${BINARY}
+	go build -ldflags="-s -w" -o ${BINARY}
 
 fmt:
 	go fmt ./...

--- a/internal/fritzutils/fritzutils.go
+++ b/internal/fritzutils/fritzutils.go
@@ -1,6 +1,8 @@
 package fritzutils
 
 import (
+	"bufio"
+	"bytes"
 	"crypto/tls"
 	"io"
 	"log"
@@ -29,6 +31,37 @@ func ReaderFromFile(path string) io.Reader {
 	}
 
 	return reader
+}
+
+func OpenFileWithNewline(path string) io.Reader {
+	file, err := os.OpenFile(path, os.O_RDONLY, 0600)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	var buffer bytes.Buffer
+	scanner := bufio.NewScanner(file)
+
+	for scanner.Scan() {
+		buffer.WriteString(scanner.Text())
+		buffer.WriteByte('\n') // Preserve existing newlines
+	}
+	if err := scanner.Err(); err != nil {
+		log.Fatal(err)
+	}
+
+	content := buffer.Bytes()
+
+	if len(content) == 0 {
+		log.Fatal("Emtpy content for '" + path + "'")
+	}
+
+	// ensure the file ends with a new line
+	if content[len(content)-1] != '\n' {
+		buffer.WriteByte('\n')
+	}
+
+	return &buffer
 }
 
 func CheckCertValidity(url *url.URL, domain string, minValidity time.Duration) (bool, bool, time.Time) {

--- a/main.go
+++ b/main.go
@@ -241,7 +241,7 @@ func setupConfiguration() (config configOptions) {
 				log.Fatal("--fullchain and --privatekey are both required, unless --bundle is used!")
 			}
 
-			config.certificateBundle = io.MultiReader(fritzutils.ReaderFromFile(config.fullchain), fritzutils.ReaderFromFile(config.privatekey))
+			config.certificateBundle = io.MultiReader(fritzutils.OpenFileWithNewline(config.fullchain), fritzutils.OpenFileWithNewline(config.privatekey))
 		}
 	}
 


### PR DESCRIPTION
🌿 improve file handling when concatenating the full chain and the private key.
If either file don't end with an empty new line, then one is added.

🐛 fixes #110

✨ when building `fritz-tls` instruct go to strip unneeded symbols from the resulting binary.
This is equivalent to running /usr/bin/strip --strip-unneeded (found in binutils).
The result is a smaller binary (87MB vs 126MB). This only affect `make build` and not the official
release as performed by Go Releaser.